### PR TITLE
Fix error on  prerendering page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import SearchBar from "@/components/search";
+import {Suspense} from "react";
 
 export default function Home() {
 
@@ -9,9 +10,11 @@ export default function Home() {
                 Fake Mail Finder
             </h2>
 
-            <div className="w-full flex items-center justify-center ">
-                <SearchBar/>
-            </div>
+            <Suspense>
+                <div className="w-full flex items-center justify-center ">
+                    <SearchBar/>
+                </div>
+            </Suspense>
 
         </main>
     );

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -2,9 +2,6 @@
     Created by Stefan Vitoria on 2/9/24
 */
 
-/*
-    Created by Stefan Vitoria on 1/1/24
-*/
 'use client';
 
 import {ChangeEvent} from "react";


### PR DESCRIPTION
The Search component was reading search parameters through useSearchParams() without a Suspense boundary will opt the entire page into client-side rendering causing the error on prerendedring the / page.
I Proceed to wrapp the Search component with Suspense boundary because it uses useSearchParams which was causing the error on build.